### PR TITLE
Feat/mysql setting with UUID

### DIFF
--- a/migrations/orm.config.ts
+++ b/migrations/orm.config.ts
@@ -2,7 +2,8 @@ import { CustomNamingStrategy } from '@app/common';
 import { DataSource } from 'typeorm';
 
 export default new DataSource({
-  type: 'postgres',
+  type: 'mysql',
+  connectorPackage: 'mysql2',
   namingStrategy: new CustomNamingStrategy(),
   host: process.env.DATABASE_HOST,
   port: +process.env.DATABASE_PORT,

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,11 +22,13 @@
         "class-validator": "^0.14.0",
         "date-fns": "^2.30.0",
         "helmet": "^7.0.0",
+        "mysql2": "^3.9.1",
         "nest-raven": "^10.0.0",
         "nest-winston": "^1.9.4",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1",
         "typeorm": "^0.3.17",
+        "uuidv7": "^0.6.3",
         "winston": "^3.10.0"
       },
       "devDependencies": {
@@ -38,7 +40,6 @@
         "@types/jest": "^29.5.2",
         "@types/morgan": "^1.9.5",
         "@types/node": "^20.3.1",
-        "@types/pg": "^8.10.2",
         "@types/supertest": "^2.0.12",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
@@ -2378,74 +2379,6 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
-    "node_modules/@types/pg": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.10.2.tgz",
-      "integrity": "sha512-MKFs9P6nJ+LAeHLU3V0cODEOgyThJ3OAnmOlsZsxux6sfQs3HRXR5bBn7xG5DjckEFhTAxsXi7k7cd0pCMxpJw==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "pg-protocol": "*",
-        "pg-types": "^4.0.1"
-      }
-    },
-    "node_modules/@types/pg/node_modules/pg-types": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.0.1.tgz",
-      "integrity": "sha512-hRCSDuLII9/LE3smys1hRHcu5QGcLs9ggT7I/TCs0IE+2Eesxi9+9RWAAwZ0yaGjxoWICF/YHLOEjydGujoJ+g==",
-      "dev": true,
-      "dependencies": {
-        "pg-int8": "1.0.1",
-        "pg-numeric": "1.0.2",
-        "postgres-array": "~3.0.1",
-        "postgres-bytea": "~3.0.0",
-        "postgres-date": "~2.0.1",
-        "postgres-interval": "^3.0.0",
-        "postgres-range": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@types/pg/node_modules/postgres-array": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.2.tgz",
-      "integrity": "sha512-6faShkdFugNQCLwucjPcY5ARoW1SlbnrZjmGl0IrrqewpvxvhSLHimCVzqeuULCbG0fQv7Dtk1yDbG3xv7Veog==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@types/pg/node_modules/postgres-bytea": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
-      "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
-      "dev": true,
-      "dependencies": {
-        "obuf": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@types/pg/node_modules/postgres-date": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.0.1.tgz",
-      "integrity": "sha512-YtMKdsDt5Ojv1wQRvUhnyDJNSr2dGIC96mQVKz7xufp07nfuFONzdaowrMHjlAzY6GDLd4f+LUHHAAM1h4MdUw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@types/pg/node_modules/postgres-interval": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
-      "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@types/qs": {
       "version": "6.9.8",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.8.tgz",
@@ -4290,6 +4223,14 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -5260,6 +5201,14 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -5818,6 +5767,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g=="
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -6828,6 +6782,11 @@
         "triple-beam": "^1.3.0"
       }
     },
+    "node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+    },
     "node_modules/lru_map": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
@@ -7064,6 +7023,43 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "node_modules/mysql2": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.9.1.tgz",
+      "integrity": "sha512-3njoWAAhGBYy0tWBabqUQcLtczZUxrmmtc2vszQUekg3kTJyZ5/IeLC3Fo04u6y6Iy5Sba7pIIa2P/gs8D3ZeQ==",
+      "dependencies": {
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.6.3",
+        "long": "^5.2.1",
+        "lru-cache": "^8.0.0",
+        "named-placeholders": "^1.1.3",
+        "seq-queue": "^0.0.5",
+        "sqlstring": "^2.3.2"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/mysql2/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mysql2/node_modules/lru-cache": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-8.0.5.tgz",
+      "integrity": "sha512-MhWWlVnuab1RG5/zMRRcVGXZLCXrZTgfwMikgzCegsPnG62yDQo5JnqKkrK4jO5iKqDAZGItAqN5CtKBCBWRUA==",
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -7072,6 +7068,25 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.3.tgz",
+      "integrity": "sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==",
+      "dependencies": {
+        "lru-cache": "^7.14.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/named-placeholders/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/natural-compare": {
@@ -7201,12 +7216,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/obuf": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
-      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
-      "dev": true
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -7564,18 +7573,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
-      "devOptional": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=4.0.0"
-      }
-    },
-    "node_modules/pg-numeric": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
-      "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/pg-pool": {
@@ -7592,7 +7593,8 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.0.tgz",
       "integrity": "sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q==",
-      "devOptional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/pg-types": {
       "version": "2.2.0",
@@ -7763,12 +7765,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/postgres-range": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.3.tgz",
-      "integrity": "sha512-VdlZoocy5lCP0c/t66xAfclglEapXPCIVhqqJRncYpvbCgImF0w67aPKfbqUMr72tO2k5q0TdTZwCLjPTI6C9g==",
-      "dev": true
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -8398,6 +8394,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
+    "node_modules/seq-queue": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
+    },
     "node_modules/serialize-javascript": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
@@ -8566,6 +8567,14 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
+    },
+    "node_modules/sqlstring": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/stack-trace": {
       "version": "0.0.10",
@@ -9540,6 +9549,14 @@
       "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/uuidv7": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/uuidv7/-/uuidv7-0.6.3.tgz",
+      "integrity": "sha512-zV3eW2NlXTsun/aJ7AixxZjH/byQcH/r3J99MI0dDEkU2cJIBJxhEWUHDTpOaLPRNhebPZoeHuykYREkI9HafA==",
+      "bin": {
+        "uuidv7": "cli.js"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -43,11 +43,13 @@
     "class-validator": "^0.14.0",
     "date-fns": "^2.30.0",
     "helmet": "^7.0.0",
+    "mysql2": "^3.9.1",
     "nest-raven": "^10.0.0",
     "nest-winston": "^1.9.4",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
     "typeorm": "^0.3.17",
+    "uuidv7": "^0.6.3",
     "winston": "^3.10.0"
   },
   "devDependencies": {
@@ -59,7 +61,6 @@
     "@types/jest": "^29.5.2",
     "@types/morgan": "^1.9.5",
     "@types/node": "^20.3.1",
-    "@types/pg": "^8.10.2",
     "@types/supertest": "^2.0.12",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",

--- a/shell/create-module.sh
+++ b/shell/create-module.sh
@@ -77,7 +77,7 @@ domain_mapper_elements=(
   "export class ${domain_mapper_class}EntityMapper {"
   "  static toDomain(entity: ${domain_mapper_class}Entity): $domain_mapper_class {"
   "    return new ${domain_mapper_class}({ ...entity }) //"
-  "      .setBase(entity.id, entity.createdAt, entity.updatedAt);"
+  "      .setBase(entity.uid, entity.id, entity.createdAt, entity.updatedAt);"
   "  }"
   "}"
 )

--- a/src/common/constant/default.constant.ts
+++ b/src/common/constant/default.constant.ts
@@ -40,8 +40,9 @@ export const defaultPlainToInstanceOptions = {
   excludeExtraneousValues: true,
 };
 
-export const defaultResponseProperties: ['id', 'createdAt', 'updatedAt'] = [
+export const defaultResponseProperties: [
+  'uid',
   'id',
   'createdAt',
   'updatedAt',
-];
+] = ['uid', 'id', 'createdAt', 'updatedAt'];

--- a/src/common/database/base.repository.ts
+++ b/src/common/database/base.repository.ts
@@ -1,4 +1,5 @@
-import { EntityManager, EntityTarget, Repository } from 'typeorm';
+import { DeepPartial, EntityManager, EntityTarget, Repository } from 'typeorm';
+import { uuidv7 } from 'uuidv7';
 
 export class BaseRepository<Entity> extends Repository<Entity> {
   constructor(
@@ -23,5 +24,53 @@ export class BaseRepository<Entity> extends Repository<Entity> {
       throw new Error('Instance is not CustomRepository child.');
     }
     return new (constructor as any)(manager);
+  }
+
+  /**
+   * uuidv7 라이브러리를 사용하여 uuid 생성
+   * @returns
+   */
+  generateUid(): string {
+    return uuidv7();
+  }
+
+  /**
+   * super.create를 override한 메서드로 uid를 생성한다.
+   * - param에 uid가 있으면 parma의 uid를 사용한다.
+   * - 새 엔티티 인스턴스를 생성합니다.
+   */
+  override create(): Entity;
+  /**
+   * super.create를 override한 메서드로 uid를 생성한다.
+   * - 새 엔티티를 생성하고 지정된 객체의 모든 엔티티 속성을 새 엔티티로 복사합니다.
+   * - param에 uid가 있으면 parma의 uid를 사용한다.
+   */
+  override create(entityLike: DeepPartial<Entity>): Entity;
+  /**
+   * super.create를 override한 메서드로 uid를 생성한다.
+   * - 새 엔티티를 생성하고 지정된 객체의 모든 엔티티 속성을 새 엔티티로 복사합니다.
+   * - param에 uid가 있으면 parma의 uid를 사용한다.
+   */
+  override create(entityLikeArray: DeepPartial<Entity>[]): Entity[];
+  /**
+   * super.create를 override한 메서드로 uid를 생성한다.
+   * - 새 엔티티를 생성하고 지정된 객체의 모든 엔티티 속성을 새 엔티티로 복사합니다.
+   * - param에 uid가 있으면 parma의 uid를 사용한다.
+   */
+  override create(
+    params?: DeepPartial<Entity> | DeepPartial<Entity>[],
+  ): Entity | Entity[] {
+    const createWithGenerateUid = (param?: DeepPartial<Entity>) =>
+      super.create({ uid: this.generateUid(), ...param });
+
+    if (!params) {
+      return createWithGenerateUid();
+    }
+
+    if (Array.isArray(params)) {
+      return params.map(createWithGenerateUid);
+    }
+
+    return createWithGenerateUid(params);
   }
 }

--- a/src/common/type/custom.type.ts
+++ b/src/common/type/custom.type.ts
@@ -4,6 +4,7 @@ export type EnvType = 'production' | 'development' | 'local';
 
 export type UserInfo = {
   id: number;
+  uid: string;
   jwt: string;
 };
 export type UserRequest = Request & { user: UserInfo };

--- a/src/config/app/environment/local.ts
+++ b/src/config/app/environment/local.ts
@@ -14,7 +14,8 @@ export const LocalConfig: AppConfig = {
   },
 
   database: {
-    type: 'postgres',
+    type: 'mysql',
+    connectorPackage: 'mysql2',
     host: process.env.DATABASE_HOST, // 개발
     port: +process.env.DATABASE_PORT,
     username: process.env.DATABASE_USER,
@@ -28,9 +29,9 @@ export const LocalConfig: AppConfig = {
     maxQueryExecutionTime:
       +process.env.DATABASE_MAX_QUERY_EXECUTION_TIME ?? 10000, // 10초
     extra: {
-      statement_timeout: +process.env.DATABASE_CONNECT_TIMEOUT ?? 60000, // 1분
-      min: +process.env.DATABASE_POOL_MIN_SIZE ?? 5,
-      max: +process.env.DATABASE_POOL_MAX_SIZE ?? 10,
+      idleTimeout: +process.env.DATABASE_IDLE_TIMEOUT ?? 60000, // 1분
+      connectionLimit: +process.env.DATABASE_CONNECTION_LIMIT ?? 5,
+      maxIdle: +process.env.DATABASE_MAX_IDLE ?? 10,
     },
   },
 

--- a/src/config/app/environment/production.ts
+++ b/src/config/app/environment/production.ts
@@ -14,7 +14,8 @@ export const ProdConfig: AppConfig = {
   },
 
   database: {
-    type: 'postgres',
+    type: 'mysql',
+    connectorPackage: 'mysql2',
     host: process.env.DATABASE_HOST,
     port: +process.env.DATABASE_PORT,
     username: process.env.DATABASE_USER,
@@ -28,9 +29,9 @@ export const ProdConfig: AppConfig = {
     maxQueryExecutionTime:
       +process.env.DATABASE_MAX_QUERY_EXECUTION_TIME ?? 10000, // 10초
     extra: {
-      statement_timeout: +process.env.DATABASE_CONNECT_TIMEOUT ?? 60000, // 1분
-      min: +process.env.DATABASE_POOL_MIN_SIZE ?? 5,
-      max: +process.env.DATABASE_POOL_MAX_SIZE ?? 10,
+      idleTimeout: +process.env.DATABASE_IDLE_TIMEOUT ?? 60000, // 1분
+      connectionLimit: +process.env.DATABASE_CONNECTION_LIMIT ?? 5,
+      maxIdle: +process.env.DATABASE_MAX_IDLE ?? 10,
     },
   },
 

--- a/src/domain/auth/auth.service.ts
+++ b/src/domain/auth/auth.service.ts
@@ -6,7 +6,7 @@ import { JwtConfig } from '@app/config';
 import { UserInfo } from '@app/common';
 import { UserRepositoryPort } from '../user/user.repository';
 
-type JwtPayload = Pick<UserInfo, 'id'>;
+type JwtPayload = Pick<UserInfo, 'uid' | 'id'>;
 
 export abstract class AuthServiceUseCase {
   abstract decodeToken(token: string): JwtPayload | null;
@@ -56,10 +56,10 @@ export class AuthService extends AuthServiceUseCase {
   }
 
   async isValid(userInfo: UserInfo): Promise<boolean> {
-    const user = await this.userRepository.findOneByPK(userInfo.id);
+    const user = await this.userRepository.findOneByPK(userInfo.uid);
     if (!user) return false;
     if (user.token !== userInfo.jwt) return false;
-    await this.userRepository.updateOneBy(user.id, {
+    await this.userRepository.updateOneBy(user.uid, {
       accessedAt: new Date(),
     });
     return true;

--- a/src/domain/auth/guard/jwt.guard.ts
+++ b/src/domain/auth/guard/jwt.guard.ts
@@ -22,7 +22,7 @@ export class JwtGuard extends BaseJwtGuard {
     const payload = this.authService.decodeToken(jwt);
     if (!payload) throw new UnauthorizedException(errorMessage.E401_APP_001);
 
-    const userInfo = { id: payload.id, jwt };
+    const userInfo = { uid: payload.uid, id: payload.id, jwt };
     const isValid = await this.authService.isValid(userInfo);
     if (!isValid) throw new UnauthorizedException(errorMessage.E401_APP_001);
 

--- a/src/domain/base.domain.ts
+++ b/src/domain/base.domain.ts
@@ -1,4 +1,5 @@
 export interface BaseDomainProps {
+  uid: string;
   id: number;
   createdAt: Date;
   updatedAt: Date;
@@ -7,12 +8,17 @@ export interface BaseDomainProps {
 export abstract class BaseDomain<PROPS> implements BaseDomainProps {
   protected props: PROPS;
 
+  #uid: string;
   #id: number;
   #createdAt: Date;
   #updatedAt: Date;
 
   protected constructor(props: PROPS) {
     this.props = props;
+  }
+
+  get uid(): string {
+    return this.#uid;
   }
 
   get id(): number {
@@ -27,7 +33,8 @@ export abstract class BaseDomain<PROPS> implements BaseDomainProps {
     return this.#updatedAt;
   }
 
-  setBase(id: number, createdAt: Date, updatedAt: Date) {
+  setBase(uid: string, id: number, createdAt: Date, updatedAt: Date) {
+    this.#uid = uid;
     this.#id = id;
     this.#createdAt = createdAt;
     this.#updatedAt = updatedAt;

--- a/src/domain/user/domain/user-entity-mapper.ts
+++ b/src/domain/user/domain/user-entity-mapper.ts
@@ -4,6 +4,6 @@ import { User } from './user.domain';
 export class UserEntityMapper {
   static toDomain(entity: UserEntity): User {
     return new User({ ...entity }) //
-      .setBase(entity.id, entity.createdAt, entity.updatedAt);
+      .setBase(entity.uid, entity.id, entity.createdAt, entity.updatedAt);
   }
 }

--- a/src/domain/user/user.controller.ts
+++ b/src/domain/user/user.controller.ts
@@ -41,7 +41,7 @@ export class UserController {
   @UseGuards(JwtGuard)
   @Get('/me')
   async getUser(
-    @GetUserInfoDecorator('id') userId: number,
+    @GetUserInfoDecorator('uid') userId: string,
   ): Promise<GetUserResponseDTO> {
     return this.userService.getUser(userId);
   }
@@ -51,7 +51,7 @@ export class UserController {
   @Patch('/me')
   @HttpCode(204)
   async patchUser(
-    @GetUserInfoDecorator('id') userId: number,
+    @GetUserInfoDecorator('uid') userId: string,
     @Body() postDto: PatchUserRequestDTO,
   ): Promise<void> {
     await this.userService.updateUser(userId, postDto);
@@ -61,7 +61,7 @@ export class UserController {
   @UseGuards(JwtGuard)
   @Delete('/me')
   @HttpCode(204)
-  async deleteUser(@GetUserInfoDecorator('id') userId: number): Promise<void> {
+  async deleteUser(@GetUserInfoDecorator('uid') userId: string): Promise<void> {
     await this.userService.softRemoveUser(userId);
   }
 }

--- a/src/domain/user/user.repository.ts
+++ b/src/domain/user/user.repository.ts
@@ -7,14 +7,14 @@ import { User, UserEntityMapper } from './domain';
 import { PostUserRequestDTO } from './dto';
 
 export abstract class UserRepositoryPort extends BaseRepository<UserEntity> {
-  abstract findOneByPK(userId: number): Promise<User | null>;
+  abstract findOneByPK(userUid: string): Promise<User | null>;
   abstract createOne(postDto: PostUserRequestDTO): Promise<User>;
   abstract updateOne(
     originUser: User,
     properties: Partial<UserEntity>,
   ): Promise<User>;
   abstract updateOneBy(
-    userId: number,
+    userUid: string,
     properties: Partial<UserEntity>,
   ): Promise<void>;
 }
@@ -27,8 +27,8 @@ export class UserRepository extends UserRepositoryPort {
     super(UserEntity, manager);
   }
 
-  async findOneByPK(userId: number): Promise<User | null> {
-    const user = await this.findOneBy({ id: userId });
+  async findOneByPK(userUid: string): Promise<User | null> {
+    const user = await this.findOneBy({ uid: userUid });
     return !!user ? UserEntityMapper.toDomain(user) : null;
   }
 
@@ -45,9 +45,9 @@ export class UserRepository extends UserRepositoryPort {
   }
 
   async updateOneBy(
-    userId: number,
+    userUid: string,
     properties: Partial<UserEntity>,
   ): Promise<void> {
-    await this.update(userId, { ...properties });
+    await this.update(userUid, { ...properties });
   }
 }

--- a/src/domain/user/user.service.ts
+++ b/src/domain/user/user.service.ts
@@ -16,12 +16,12 @@ export abstract class UserServiceUseCase {
   abstract createUser(
     postDto: PostUserRequestDTO,
   ): Promise<PostUserResponseDTO>;
-  abstract getUser(userId: number): Promise<GetUserResponseDTO>;
+  abstract getUser(userUid: string): Promise<GetUserResponseDTO>;
   abstract updateUser(
-    userId: number,
+    userUid: string,
     postDto: PatchUserRequestDTO,
   ): Promise<void>;
-  abstract softRemoveUser(userId: number): Promise<void>;
+  abstract softRemoveUser(userUid: string): Promise<void>;
 }
 
 @Injectable()
@@ -45,6 +45,7 @@ export class UserService extends UserServiceUseCase {
       const newUser = await txUserRepo.createOne(postDto);
 
       const token = this.authService.issueToken({
+        uid: newUser.uid,
         id: newUser.id,
       });
       const nickname = postDto.nickname ?? newUser.generateNickname().nickname;
@@ -63,8 +64,8 @@ export class UserService extends UserServiceUseCase {
     }
   }
 
-  async getUser(userId: number): Promise<GetUserResponseDTO> {
-    const user = await this.userRepo.findOneByPK(userId);
+  async getUser(userUid: string): Promise<GetUserResponseDTO> {
+    const user = await this.userRepo.findOneByPK(userUid);
     if (!user) throw new NotFoundException(errorMessage.E404_APP_001);
     return Util.toInstance(GetUserResponseDTO, {
       ...user.props,
@@ -72,17 +73,17 @@ export class UserService extends UserServiceUseCase {
   }
 
   async updateUser(
-    userId: number,
+    userUid: string,
     postDto: PatchUserRequestDTO,
   ): Promise<void> {
-    const user = await this.userRepo.findOneByPK(userId);
+    const user = await this.userRepo.findOneByPK(userUid);
     if (!user) throw new NotFoundException(errorMessage.E404_APP_001);
-    await this.userRepo.updateOneBy(userId, { ...postDto });
+    await this.userRepo.updateOneBy(userUid, { ...postDto });
   }
 
-  async softRemoveUser(userId: number): Promise<void> {
-    const user = await this.userRepo.findOneByPK(userId);
+  async softRemoveUser(userUid: string): Promise<void> {
+    const user = await this.userRepo.findOneByPK(userUid);
     if (!user) throw new NotFoundException(errorMessage.E404_APP_001);
-    await this.userRepo.softDelete(userId);
+    await this.userRepo.softDelete(userUid);
   }
 }

--- a/src/entity/base.entity.ts
+++ b/src/entity/base.entity.ts
@@ -1,6 +1,7 @@
 import { ApiHideProperty, ApiProperty } from '@nestjs/swagger';
 import { Exclude, Expose } from 'class-transformer';
 import {
+  Column,
   CreateDateColumn,
   DeleteDateColumn,
   PrimaryGeneratedColumn,
@@ -8,23 +9,28 @@ import {
 } from 'typeorm';
 
 export class BaseEntity {
+  @ApiProperty({ description: '엔티티 uid', type: String })
+  @Expose()
+  @PrimaryGeneratedColumn('uuid')
+  readonly uid: string;
+
   @ApiProperty({ description: '엔티티 id', type: Number })
   @Expose()
-  @PrimaryGeneratedColumn()
-  id: number;
+  @Column('int', { generated: 'increment', unique: true })
+  readonly id: number;
 
   @ApiProperty({ description: '생성일', type: Date })
   @Expose()
-  @CreateDateColumn({ type: 'timestamptz' })
-  createdAt: Date;
+  @CreateDateColumn({ type: 'datetime' })
+  readonly createdAt: Date;
 
   @ApiProperty({ description: '수정일', type: Date })
   @Expose()
-  @UpdateDateColumn({ type: 'timestamptz' })
-  updatedAt: Date;
+  @UpdateDateColumn({ type: 'datetime' })
+  readonly updatedAt: Date;
 
   @ApiHideProperty()
   @Exclude()
-  @DeleteDateColumn({ type: 'timestamptz' })
+  @DeleteDateColumn({ type: 'datetime' })
   deletedAt: Date;
 }

--- a/src/entity/user/user.entity.ts
+++ b/src/entity/user/user.entity.ts
@@ -41,7 +41,7 @@ export class UserEntity extends BaseEntity {
   @ApiHideProperty()
   @Exclude()
   @DateValidator()
-  @Column('timestamptz', { comment: '마지막 접속일', default: () => 'NOW()' })
+  @Column('datetime', { comment: '마지막 접속일', default: () => 'NOW()' })
   accessedAt: Date;
 
   @ApiHideProperty()


### PR DESCRIPTION
# PR Summery

## [FEATURE]

    - Typeorm 설정 mysql2로 변경
    - Entity uid 추가 및 PK를 uid로 변경, 기존 id는 유니크 키와 auto_increment 설정
    - API 및 JwtGuard id를 사용하는 코드 uid를 사용하도록 일괄 수정
    - BaseRepogitory#generateUid() 신규 추가
    - BaseRepogitory#create() uid를 기본적으로 생성하도록 override 수행
    
## [ISSUE] (optional)

    - package 라이브러리 추가: `"mysql2": "^3.9.1"`, `"uuidv7": "^0.6.3",`
    - package 개발 라이브러리 제거: `@types/pg` 